### PR TITLE
Point to Github Repository and added package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Zudem werde ich die Beispiele ein wenig vereinfachen, so dass zwar nicht alle wi
 Dieses Tutorial wurde für die Serverliste MCSEU erstellt.  
 Sollte es Fragen oder Anmerkungen zu meinem Guideline geben, so bin ich dort die meiste Zeit zu erreichen.
 
-Außerdem bin ich natürlich auch auf [GitHub ](https://github.com/Xhadius "Hier sollte ohnehin jeder FOSS-Liebhaber zu finden sein :)")vertreten.
+Außerdem bin ich natürlich auch auf [GitHub](https://github.com/Xhadius/MySQL-auf-einem-Linux-System-einrichten "Hier sollte ohnehin jeder FOSS-Liebhaber zu finden sein :)") vertreten.
 
 ## Lizenz
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mysql-auf-linux",
+  "version": "1.0.0",
+  "description": "Tutorial describing the installation of MySQL on a Linux Server.",
+  "dependencies": {
+    "gitbook-cli": "^2.3.0"
+  },
+  "scripts": {
+    "serve": "gitbook serve"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Xhadius/MySQL-auf-einem-Linux-System-einrichten.git"
+  },
+  "author": "Xhadius",
+  "license": "CC-BY-4.0",
+  "bugs": {
+    "url": "https://github.com/Xhadius/MySQL-auf-einem-Linux-System-einrichten/issues"
+  },
+  "homepage": "https://github.com/Xhadius/MySQL-auf-einem-Linux-System-einrichten"
+}


### PR DESCRIPTION
A package.json simplifies forking, because a
developer simply runs npm install to install the
relevant dependencies (namely Gitbook) and also
provides a simple wrapper command to start the
internal Gitbook Webserver (e.g. npm run serve).

And the Space after GitHub was removed. Looking kind of weird while hovering over it.

Signed-off-by: Bjoern Heinrichs <manfie@protonmail.ch>